### PR TITLE
change position fixed to absolute for rounded border corner indents

### DIFF
--- a/src/components/ocean/Ocean.module.css
+++ b/src/components/ocean/Ocean.module.css
@@ -59,7 +59,7 @@
     background: goldenrod;
     height: 4vw;
     width: 4vw;
-    position: fixed;
+    position: absolute;
   }
 
   .CornerNW {
@@ -145,7 +145,7 @@
         transform: rotate(-90deg);
         transform-origin: left top;
 
-        position: absolute;
+        position: fixed;
         top: 100%; 
         
         height: 100vw;
@@ -184,8 +184,6 @@
     .Title {
       font-size: 2.75vw;
     }
-    
-    
 }
 
 @media screen and (max-width: 500px) and (orientation: portrait) {
@@ -226,5 +224,4 @@
   .Title {
     font-size: 3.25vw;
   }
-
 }


### PR DESCRIPTION
Update to keep the rounded border corner indents attached to the border, which they seem to have not been on mobile browsers.